### PR TITLE
Function to make enc from pre-allocated slice

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -10,11 +10,16 @@ type Enc struct {
 	off *uint64
 }
 
-func NewEnc(sz uint64) Enc {
+func NewEncFromSlice(b []byte) Enc {
 	return Enc{
-		b:   make([]byte, sz),
+		b:   b,
 		off: new(uint64),
 	}
+}
+
+func NewEnc(sz uint64) Enc {
+	b := make([]byte, sz)
+	return NewEncFromSlice(b)
 }
 
 func (enc Enc) PutInt(x uint64) {


### PR DESCRIPTION
Many times, a thread can re-use a buffer for encoding. On the i3.metal NVMe, encoding hdr1 in the logger for GoJournal takes about as long as issuing a barrier, half of which is devoted to GC related events due to allocating a fresh slice for the encoder every time.