### PR TITLE
add method to get remaining bytes from a Dec

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -102,6 +102,11 @@ func (dec Dec) GetBytes(num uint64) []byte {
 	return b
 }
 
+func (dec Dec) GetRemainingBytes() []byte {
+	remaining := uint64(len(dec.b)) - *dec.off
+	return dec.GetBytes(remaining)
+}
+
 func (dec Dec) GetBool() bool {
 	off := *dec.off
 	*dec.off += 1


### PR DESCRIPTION
This is quite useful to parse e.g. 2 integers from the front of a package, and then let some other part of the code continue parsing the rest.