### PR TITLE
Swap writeSlice writeOne args order

### DIFF
--- a/stateless_slice.go
+++ b/stateless_slice.go
@@ -16,15 +16,15 @@ func ReadSliceLenPrefix[T any](b []byte, readOne func(b []byte) (T, []byte)) ([]
 	return ReadSlice(b2, count, readOne)
 }
 
-func WriteSlice[T any](b []byte, xs []T, writeOne func(x T, b []byte) []byte) []byte {
+func WriteSlice[T any](b []byte, xs []T, writeOne func(b []byte, x T) []byte) []byte {
 	var b2 = b
 	for _, x := range xs {
-		b2 = writeOne(x, b2)
+		b2 = writeOne(b2, x)
 	}
 	return b2
 }
 
-func WriteSliceLenPrefix[T any](b []byte, xs []T, writeOne func(x T, b []byte) []byte) []byte {
+func WriteSliceLenPrefix[T any](b []byte, xs []T, writeOne func(b []byte, x T) []byte) []byte {
 	b2 := WriteInt(b, uint64(len(xs)))
 	b3 := WriteSlice(b2, xs, writeOne)
 	return b3

--- a/stateless_test.go
+++ b/stateless_test.go
@@ -84,7 +84,7 @@ func readThings(b []byte) (x things, b2 []byte) {
 	return
 }
 
-func writeThings(x things, b []byte) []byte {
+func writeThings(b []byte, x things) []byte {
 	b2 := b
 	b2 = WriteInt(b2, x.x)
 	b2 = WriteInt(b2, x.y)

--- a/stateless_test.go
+++ b/stateless_test.go
@@ -105,3 +105,13 @@ func TestStatelessWriteSlice(t *testing.T) {
 	assert.Empty(b_extra)
 	assert.Equal(xs, xs2)
 }
+
+func TestStatelessIntSlice(t *testing.T) {
+	assert := assert.New(t)
+	numbers := []uint64{0, 123, 1 << 58, 1 << 48}
+	data := WriteSlice([]byte{}, numbers, WriteInt)
+	result, b_extra := ReadSlice(data, 4, ReadInt)
+
+	assert.Empty(b_extra)
+	assert.Equal(numbers, result)
+}


### PR DESCRIPTION
After completing grackle support for slices of structs, I wanted to make sure that grackle also supports things like slices of integers, which are used way more than slices of structs. 

Much to my surprise, it doesn't and the issue is due to the current marshaling API. Currently, `WriteSlice` expects the `writeOne` argument to have this type:
```go
writeOne func(x T, b []byte) []byte
```
while the existing write functions, such as `WriteInt` have types like this:
```go 
WriteInt(b []byte, i uint64) []byte
```

Notice the different in the order of the arguments. 

I've elected to change the slice marshaling code to match, even though this is going to create more work for grackle since it should protect the other perennial projects currently using the marshaling code from needing to be updated. 