### PR TITLE
Add ReadLenPrefixedBytesCopy

### DIFF
--- a/stateless.go
+++ b/stateless.go
@@ -82,6 +82,12 @@ func ReadLenPrefixedBytes(b []byte) ([]byte, []byte) {
 	return bs, b3
 }
 
+func ReadLenPrefixedBytesCopy(b []byte) ([]byte, []byte) {
+	l, b2 := ReadInt(b)
+	bs, b3 := ReadBytesCopy(b2, l)
+	return bs, b3
+}
+
 /* Functions for the stateless encoder API */
 
 // WriteInt appends i in little-endian format to b, returning the new slice.


### PR DESCRIPTION
Adds a new helper function `ReadLenPrefixedBytesCopy` which is like `ReadLenPrefixedBytes` but calls `ReadBytesCopy` instead. 